### PR TITLE
Export gui instance directly from url_args

### DIFF
--- a/url_args.js
+++ b/url_args.js
@@ -1,6 +1,6 @@
 let q_args = new URLSearchParams(location.search);
 let args_info = [];
-let gui = window.dat && new dat.GUI({ autoPlace: true });
+export const gui = window.dat && new dat.GUI({ autoPlace: true });
 let log2 = Math.log2;
 
 export const vconf = { onchange: null };


### PR DESCRIPTION
## Summary
- export the dat.GUI instance directly from `url_args.js` to avoid redundant identifiers

## Testing
- Manual verification in Playwright – loaded the home page and clicked the Open button to ensure no console errors

------
https://chatgpt.com/codex/tasks/task_e_68def612db588332bdec748723e5560d